### PR TITLE
Fixed adding of images and audio from immersion kit

### DIFF
--- a/yuuna/lib/src/creator/enhancements/immersion_kit_enhancement.dart
+++ b/yuuna/lib/src/creator/enhancements/immersion_kit_enhancement.dart
@@ -104,6 +104,18 @@ class ImmersionKitEnhancement extends Enhancement {
         creatorModel.getFieldController(SentenceField.instance).text =
             selection.map((result) => result.text).join('\n\n');
 
+      },
+      onAppend: (selection) async {
+        if (selection.isEmpty) {
+          return;
+        }
+
+        String currentSentence =
+            creatorModel.getFieldController(SentenceField.instance).text;
+
+        creatorModel.getFieldController(SentenceField.instance).text =
+            '${currentSentence.trim()}\n\n${selection.map((result) => result.text).join('\n\n')}'
+                .trim();
         if (selection.first.imageUrl.isNotEmpty) {
           await ImageField.instance.setImages(
             cause: cause,
@@ -140,18 +152,6 @@ class ImmersionKitEnhancement extends Enhancement {
             },
           );
         }
-      },
-      onAppend: (selection) async {
-        if (selection.isEmpty) {
-          return;
-        }
-
-        String currentSentence =
-            creatorModel.getFieldController(SentenceField.instance).text;
-
-        creatorModel.getFieldController(SentenceField.instance).text =
-            '${currentSentence.trim()}\n\n${selection.map((result) => result.text).join('\n\n')}'
-                .trim();
       },
     );
   }


### PR DESCRIPTION
More of a note of a regression in the immersion kit functionality. Adding of images and audio from immersion kit suddenly stopped working on the newest version so I traced down the issue. The code that adds the images and audio to the notes was moved from the onAppend event to onSelect event. Since there doesn't seem to be support for multiple images (?) at least I thought that it would be fine to move the code back for now.

Not sure if there was some idea behind the change, but since I use this feature I thought I might as well make pull request for it just in case. Feel free to reject if I missed something.