### PR TITLE
fix: Plain furigana output to use spaces instead of empty `[ ]`

### DIFF
--- a/yuuna/lib/src/creator/fields/furigana_field.dart
+++ b/yuuna/lib/src/creator/fields/furigana_field.dart
@@ -49,11 +49,10 @@ class FuriganaField extends Field {
 
     StringBuffer buffer = StringBuffer();
     for (RubyTextData rubyData in rubyDatas) {
-      buffer.write(rubyData.text);
       if (rubyData.ruby != null && rubyData.ruby!.trim().isNotEmpty) {
-        buffer.write('[${rubyData.ruby}]');
+        buffer.write(' ${rubyData.text}[${rubyData.ruby}]');
       } else {
-        buffer.write('[ ]');
+        buffer.write(rubyData.text);
       }
     }
 


### PR DESCRIPTION
See discussion here: https://discord.com/channels/617136488840429598/1107818096242212864/1108516668306636890

To summarize, the bug was that plain furigana output was `怯[おび]える[ ]`, when it should ideally be `怯[おび]える` (or ` 怯[おび]える`). Using the initial form technically works for pretty much all cases, but fails with Anki's `kana` filter (i.e. `{{kana:Expression}}` -> `おび` when it should be `おびえる`).

Untested since I don't have flutter.