### PR TITLE
Fix for Meaning Tag Being Null in Yomichan Term Bank

### DIFF
--- a/yuuna/lib/src/dictionary/formats/yomichan_dictionary_format.dart
+++ b/yuuna/lib/src/dictionary/formats/yomichan_dictionary_format.dart
@@ -81,7 +81,13 @@ Future<Map<DictionaryHeading, List<DictionaryEntry>>>
         String reading = item[1] as String;
 
         double popularity = (item[4] as num).toDouble();
-        List<String> entryTagNames = (item[2] as String).split(' ');
+
+        // Third entry in array can be null
+        List<String> entryTagNames = [];
+        if (item[2] != null) {
+          entryTagNames = (item[2] as String).split(' ');
+        }
+
         List<String> headingTagNames = (item[7] as String).split(' ');
 
         List<String> definitions = [];


### PR DESCRIPTION
The third term (meaning tags) in a term bank entry being null apparently causes jidoujisho to fail to import the dictionary, according to avc1657. Here is an [example dictionary](https://cdn.discordapp.com/attachments/778430038159655012/1133566176555962468/meikyo2_text_only.zip) with such an entry.