### PR TITLE
Migaku Dictionary - Get reading from 'pronunciation' field

### DIFF
--- a/yuuna/lib/src/dictionary/formats/migaku_dictionary_format.dart
+++ b/yuuna/lib/src/dictionary/formats/migaku_dictionary_format.dart
@@ -72,14 +72,15 @@ void prepareEntriesMigakuFormat({
 
       String term = (map['term'] as String).trim();
       String definition = map['definition'] as String;
+      String reading = map['pronunciation'] ?? '';
 
       definition = definition
           .replaceAll('<br>', '\n')
           .replaceAll(RegExp('<[^<]+?>'), '');
 
-      int headingId = DictionaryHeading.hash(term: term, reading: '');
+      int headingId = DictionaryHeading.hash(term: term, reading: reading);
       DictionaryHeading heading = isar.dictionaryHeadings.getSync(headingId) ??
-          DictionaryHeading(term: term);
+          DictionaryHeading(term: term, reading: reading);
 
       DictionaryEntry entry = DictionaryEntry(
         definitions: [definition],


### PR DESCRIPTION
Migaku dictionaries have a field for the readings - `pronunciation` - but it wasn't being picked up when importing.

[Migaku dictionary format](https://legacy.migaku.io/tools-guides/migaku-dictionary/manual/#migaku-dictionary-format)

The dictionaries I was testing with are [in this gdrive folder](https://drive.google.com/drive/folders/1_A4duHnP-nVXhChy05DU_EU4CX3bTf6J) (language is cantonese, but it seems perfectly compatible with the japanese target settings)