### PR TITLE
Update Anki-Android dependency version

### DIFF
--- a/yuuna/android/app/build.gradle
+++ b/yuuna/android/app/build.gradle
@@ -117,6 +117,6 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.github.ankidroid:Anki-Android:api-v1.1.0'
+    implementation 'com.github.ankidroid:Anki-Android:2.17alpha14'
     implementation 'com.github.umair13adil:RxLogs:v1.0.18'
 }


### PR DESCRIPTION
Fixes build issues due to jitpack not having the necessary files for api-v1.1.0

I *think* it also fixes the new ankidroid backend issue #301, but I've only really been able to test on my specific device and I can't be sure it was the same issue I was seeing.