### PR TITLE
feature: sort by longest exact match in immersion kit & massif

### DIFF
--- a/yuuna/lib/src/creator/enhancements/immersion_kit_enhancement.dart
+++ b/yuuna/lib/src/creator/enhancements/immersion_kit_enhancement.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -251,19 +250,14 @@ class ImmersionKitEnhancement extends Enhancement {
     int textPosition = wordList.sublist(0, wordIndices.first).join().length;
     int termPosition = 0;
 
-    int longest = 0;
-
-    var termChar = term.characters.elementAtOrNull(termPosition);
-    var textChar = text.characters.elementAtOrNull(textPosition);
-    while (textChar != null && termChar != null && termChar == textChar) {
-      longest++;
+    while (textPosition < text.length &&
+        termPosition < term.length &&
+        term[termPosition] == text[textPosition]) {
       termPosition++;
       textPosition++;
-      termChar = term.characters.elementAtOrNull(termPosition);
-      textChar = text.characters.elementAtOrNull(textPosition);
     }
 
-    return longest;
+    return termPosition;
   }
 
   /// Search the Massif API for example sentences and return a list of results.

--- a/yuuna/lib/src/creator/enhancements/immersion_kit_enhancement.dart
+++ b/yuuna/lib/src/creator/enhancements/immersion_kit_enhancement.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -26,6 +27,7 @@ class ImmersionKitResult {
     required this.wordList,
     required this.wordIndices,
     required this.calculateRange,
+    required this.longestExactMatch,
   });
 
   /// The sentence in plain unformatted form.
@@ -47,6 +49,9 @@ class ImmersionKitResult {
   List<int> wordIndices;
 
   TextRange? _calculatedRange;
+
+  /// How many consecutive characters match the search term exactly
+  int longestExactMatch;
 
   /// Function to calculate the range of search term
   TextRange Function() calculateRange;
@@ -236,6 +241,31 @@ class ImmersionKitEnhancement extends Enhancement {
     }
   }
 
+  int _longestExactRangeForResult({
+    required List<int> wordIndices,
+    required List<String> wordList,
+    required String term,
+    required String text,
+  }) {
+    /// Start at the first character of the given cloze
+    int textPosition = wordList.sublist(0, wordIndices.first).join().length;
+    int termPosition = 0;
+
+    int longest = 0;
+
+    var termChar = term.characters.elementAtOrNull(termPosition);
+    var textChar = text.characters.elementAtOrNull(textPosition);
+    while (textChar != null && termChar != null && termChar == textChar) {
+      longest++;
+      termPosition++;
+      textPosition++;
+      termChar = term.characters.elementAtOrNull(termPosition);
+      textChar = text.characters.elementAtOrNull(textPosition);
+    }
+
+    return longest;
+  }
+
   /// Search the Massif API for example sentences and return a list of results.
   Future<List<ImmersionKitResult>> searchForSentences({
     required AppModel appModel,
@@ -290,18 +320,23 @@ class ImmersionKitEnhancement extends Enhancement {
         String audioUrl = example['sound_url'];
 
         ImmersionKitResult result = ImmersionKitResult(
-          text: text,
-          source: source,
-          imageUrl: imageUrl,
-          audioUrl: audioUrl,
-          wordList: wordList,
-          wordIndices: wordIndices,
-          calculateRange: () => _getRangeFromIndexedList(
-            wordIndices: wordIndices,
+            text: text,
+            source: source,
+            imageUrl: imageUrl,
+            audioUrl: audioUrl,
             wordList: wordList,
-            term: searchTerm,
-          ),
-        );
+            wordIndices: wordIndices,
+            calculateRange: () => _getRangeFromIndexedList(
+                  wordIndices: wordIndices,
+                  wordList: wordList,
+                  term: searchTerm,
+                ),
+            longestExactMatch: _longestExactRangeForResult(
+              wordIndices: wordIndices,
+              wordList: wordList,
+              text: text,
+              term: searchTerm,
+            ));
 
         /// Sentence examples that are merely the word itself are pretty
         /// redundant.
@@ -313,7 +348,7 @@ class ImmersionKitEnhancement extends Enhancement {
       /// Make sure series aren't too consecutive.
       results.shuffle();
 
-      /// Results with images come first.
+      /// Sort by: has image -> has audio -> longest exact match -> shortest sentence
       results.sort((a, b) {
         int hasImage = (a.imageUrl.isNotEmpty ? -1 : 1)
             .compareTo(b.imageUrl.isNotEmpty ? -1 : 1);
@@ -327,6 +362,13 @@ class ImmersionKitEnhancement extends Enhancement {
 
         if (hasAudio != 0) {
           return hasAudio;
+        }
+
+        /// Sort by longest subterm
+        int longestMatch = b.longestExactMatch.compareTo(a.longestExactMatch);
+
+        if (longestMatch != 0) {
+          return longestMatch;
         }
 
         return a.text.length.compareTo(b.text.length);


### PR DESCRIPTION
Makes a slight improvement to sorting in immersion kit. For words where there are a lot of unfitting results returned by immersion kit, this should float the best ones to the top. 

### ImmersionKit Example:
Compound verbs such as `聞き入る`

Before             |  After
:-------------------------:|:-------------------------:
![image](https://github.com/lrorpilla/jidoujisho/assets/44649263/02dfa8e5-e9b6-4809-8629-c15c93fe3ad9)  |  ![image](https://github.com/lrorpilla/jidoujisho/assets/44649263/5bfee7f1-06f4-4252-a088-cc0326fbd6ae)

Rare kanji versions of common words such as `成る`

Before             |  After
:-------------------------:|:-------------------------:
![image](https://github.com/lrorpilla/jidoujisho/assets/44649263/6d517aab-b1c9-448b-b155-defbc3fe943a)  | ![image](https://github.com/lrorpilla/jidoujisho/assets/44649263/f99b0cf0-73ce-4f0c-b02b-355cf19c0d7c)

### Massif Example:

Compound verbs such as `聞き入る`

Before             |  After
:-------------------------:|:-------------------------:
 ![image](https://github.com/lrorpilla/jidoujisho/assets/44649263/89f659cc-9ae5-46e8-9533-8700e89a8c32) | ![image](https://github.com/lrorpilla/jidoujisho/assets/44649263/93bd1a06-e192-4008-832d-e8adf2beae23)

Rare kanji versions of common words such as `聴き入る`

Before             |  After
:-------------------------:|:-------------------------:
![image](https://github.com/lrorpilla/jidoujisho/assets/44649263/84d1625c-8763-432a-948e-cb91e172cb21) | ![image](https://github.com/lrorpilla/jidoujisho/assets/44649263/c04c8e44-2b17-4fc3-a858-bf74d2ebb65b)